### PR TITLE
Improve pathfinder performance

### DIFF
--- a/Marvin/InfluenceMap.cpp
+++ b/Marvin/InfluenceMap.cpp
@@ -32,7 +32,10 @@ void InfluenceMap::Clear() {
 
 void InfluenceMap::Decay(float dt) {
   for (size_t i = 0; i < 1024 * 1024; ++i) {
-    tiles[i] = std::max(0.0f, tiles[i] - dt);
+    tiles[i] = tiles[i] - dt;
+    if (tiles[i] < 0) {
+      tiles[i] = 0;
+    }
   }
 }
 

--- a/Marvin/path/Node.h
+++ b/Marvin/path/Node.h
@@ -17,28 +17,21 @@ struct NodePoint {
   bool operator==(const NodePoint& other) const { return x == other.x && y == other.y; }
 };
 
+enum { NodeFlag_Openset = (1 << 0), NodeFlag_Closed = (1 << 1), NodeFlag_Initialized = (1 << 2) };
+typedef u32 NodeFlags;
+
 struct Node {
-  NodePoint point;
   Node* parent;
+
   float g;
-  float h;
   float f;
+
   float weight;
   float previous_weight;
-  uint32_t rotations;
-  bool closed;
-  bool openset;
 
-  Node()
-      : closed(false),
-        openset(false),
-        parent(nullptr),
-        g(0.0f),
-        h(0.0f),
-        f(0.0f),
-        weight(1.0f),
-        previous_weight(1.0f),
-        rotations(0) {}
+  u8 flags;
+
+  Node() : flags(0), parent(nullptr), g(0.0f), f(0.0f), weight(1.0f), previous_weight(1.0f) {}
 };
 
 }  // namespace path

--- a/Marvin/path/NodeProcessor.h
+++ b/Marvin/path/NodeProcessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <unordered_map>
 #include <vector>
 
@@ -21,13 +22,11 @@ struct NodeConnections {
 class NodeProcessor {
  public:
   NodeProcessor(GameProxy& game) : game_(game), map_(game.GetMap()) {
-    // NodeProcessor(const Map & map) : map_(map) {
     nodes_.resize(kMaxNodes);
+    memset(&nodes_[0], 0, kMaxNodes * sizeof(Node));
   }
 
   GameProxy& GetGame() { return game_; }
-
-  void ResetNodes();
 
   bool Mined(std::vector<Vector2f> mines, NodePoint point);
 
@@ -35,6 +34,17 @@ class NodeProcessor {
   NodeConnections FindEdges(std::vector<Vector2f> mines, Node* node, Node* start, Node* goal, float radius);
   Node* GetNode(NodePoint point);
   bool IsSolid(u16 x, u16 y) { return map_.IsSolid(x, y); }
+
+  // Calculate the node from the index.
+  // This lets the node exist without storing its position so it fits in cache better.
+  inline NodePoint GetPoint(const Node* node) const {
+    size_t index = (node - &nodes_[0]);
+
+    uint16_t world_y = (uint16_t)(index / 1024);
+    uint16_t world_x = (uint16_t)(index % 1024);
+
+    return NodePoint(world_x, world_y);
+  }
 
  private:
   std::vector<Node> nodes_;

--- a/Marvin/path/Pathfinder.h
+++ b/Marvin/path/Pathfinder.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 #include "../Vector2f.h"
@@ -51,7 +52,7 @@ class PriorityQueue {
 
 struct Pathfinder {
  public:
-  Pathfinder(std::unique_ptr<NodeProcessor> processor);
+  Pathfinder(std::unique_ptr<NodeProcessor> processor, RegionRegistry& regions);
   std::vector<Vector2f> FindPath(const Map& map, std::vector<Vector2f> mines, const Vector2f& from, const Vector2f& to,
                                  float radius);
 
@@ -63,14 +64,13 @@ struct Pathfinder {
 
  private:
   struct NodeCompare {
-    bool operator()(const Node* lhs, const Node* rhs) const {
-      if (lhs->f == rhs->f) return lhs->rotations > rhs->rotations;
-      return lhs->f > rhs->f;
-    }
+    bool operator()(const Node* lhs, const Node* rhs) const { return lhs->f > rhs->f; }
   };
 
   std::unique_ptr<NodeProcessor> processor_;
+  RegionRegistry& regions_;
   PriorityQueue<Node*, NodeCompare> openset_;
+  std::unordered_set<Node*> touched_nodes_;
 };
 
 }  // namespace path

--- a/Marvin/zones/ExtremeGames.cpp
+++ b/Marvin/zones/ExtremeGames.cpp
@@ -26,8 +26,9 @@ ExtremeGames::ExtremeGames(std::shared_ptr<marvin::GameProxy> game)
     ship_ = 2;
   }
 
-  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor));
   regions_ = RegionRegistry::Create(game_->GetMap());
+
+  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor), *regions_);
   pathfinder_->CreateMapWeights(game_->GetMap());
 
   auto freq_warp_attach = std::make_unique<eg::FreqWarpAttachNode>();

--- a/Marvin/zones/GalaxySports.cpp
+++ b/Marvin/zones/GalaxySports.cpp
@@ -26,8 +26,9 @@ GalaxySports::GalaxySports(std::shared_ptr<marvin::GameProxy> game)
     ship_ = 1;
   }
 
-  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor));
   regions_ = RegionRegistry::Create(game_->GetMap());
+
+  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor), *regions_);
   pathfinder_->CreateMapWeights(game_->GetMap());
 
   auto freq_warp_attach = std::make_unique<gs::FreqWarpAttachNode>();

--- a/Marvin/zones/Hockey.cpp
+++ b/Marvin/zones/Hockey.cpp
@@ -26,8 +26,9 @@ Hockey::Hockey(std::shared_ptr<marvin::GameProxy> game)
     ship_ = 2;
   }
 
-  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor));
   regions_ = RegionRegistry::Create(game_->GetMap());
+
+  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor), *regions_);
   pathfinder_->CreateMapWeights(game_->GetMap());
 
   auto find_enemy = std::make_unique<hz::FindEnemyNode>();

--- a/Marvin/zones/PowerBall.cpp
+++ b/Marvin/zones/PowerBall.cpp
@@ -26,8 +26,9 @@ PowerBall::PowerBall(std::shared_ptr<marvin::GameProxy> game)
     ship_ = 1;
   }
 
-  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor));
   regions_ = RegionRegistry::Create(game_->GetMap());
+
+  pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor), *regions_);
   pathfinder_->CreateMapWeights(game_->GetMap());
 
   FindPowerBallGoal();
@@ -133,10 +134,11 @@ void PowerBall::Update(float dt) {
     powerball_arena_ = game_->GetMapFile();
 
     auto processor = std::make_unique<path::NodeProcessor>(*game_);
-    pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor));
+    regions_ = RegionRegistry::Create(game_->GetMap());
+
+    pathfinder_ = std::make_unique<path::Pathfinder>(std::move(processor), *regions_);
 
     ctx_.blackboard.Set("path", std::vector<Vector2f>());
-    regions_ = RegionRegistry::Create(game_->GetMap());
     pathfinder_->CreateMapWeights(game_->GetMap());
 
     // set new goals


### PR DESCRIPTION
- Always push nodes onto the openset priority queue instead of
  rebuilding the queue on a change.
- Fix a bug where the fitness wasn't being compared correctly. This
  resulted in a lot of nodes being checked that didn't need to be
  checked.
- Early exit in pathfinder if the two positions aren't in the same
  connected region.
- Shrink the size of nodes to improve cache performance.
- Change node reset so it only resets the touched nodes instead of
  entire map every pathfind request.
- Improve influence map decay performance.