### PR TITLE
Improve aim calculations

### DIFF
--- a/Marvin/Debug.cpp
+++ b/Marvin/Debug.cpp
@@ -28,6 +28,30 @@ void RenderWorldLine(Vector2f screenCenterWorldPosition, Vector2f from, Vector2f
   RenderLine(center + from, center + to, color);
 }
 
+void RenderWorldBox(Vector2f screenCenterWorldPosition, Vector2f box_top_left, Vector2f box_bottom_right,
+                    COLORREF color) {
+  Vector2f diff = box_bottom_right - box_top_left;
+
+  Vector2f box_top_right = box_top_left + Vector2f(diff.x, 0);
+  Vector2f box_bottom_left = box_top_left + Vector2f(0, diff.y);
+
+  RenderWorldLine(screenCenterWorldPosition, box_top_left, box_top_right, color);
+  RenderWorldLine(screenCenterWorldPosition, box_top_right, box_bottom_right, color);
+  RenderWorldLine(screenCenterWorldPosition, box_top_left, box_bottom_left, color);
+  RenderWorldLine(screenCenterWorldPosition, box_bottom_left, box_bottom_right, color);
+}
+
+void RenderWorldText(Vector2f screenCenterWorldPosition, const std::string& text, const Vector2f& at, TextColor color,
+                     int flags) {
+  Vector2f center = GetWindowCenter();
+
+  Vector2f screen_at = center + (at - screenCenterWorldPosition) * 16.0f;
+
+  if (screen_at.x > 0 && screen_at.y > 0 && screen_at.x < center.x * 2 && screen_at.y < center.y * 2) {
+    RenderText(text, screen_at, color, flags);
+  }
+}
+
 void RenderState::Render() {
   u32 graphics_addr = *(u32*)(0x4C1AFC) + 0x30;
   LPDIRECTDRAWSURFACE back_surface = (LPDIRECTDRAWSURFACE) * (u32*)(graphics_addr + 0x44);
@@ -148,6 +172,10 @@ void RenderPath(Vector2f position, std::vector<Vector2f> path) {
 void RenderState::Render() {}
 
 void RenderWorldLine(Vector2f screenCenterWorldPosition, Vector2f from, Vector2f to, COLORREF color) {}
+void RenderWorldBox(Vector2f screenCenterWorldPosition, Vector2f box_top_left, Vector2f box_bottom_right,
+                    COLORREF color) {}
+void RenderWorldText(Vector2f screenCenterWorldPosition, const std::string& text, const Vector2f& at, TextColor color,
+                     int flags) {}
 
 void RenderLine(Vector2f from, Vector2f to, COLORREF color) {}
 

--- a/Marvin/Debug.h
+++ b/Marvin/Debug.h
@@ -11,6 +11,7 @@
 #define DEBUG_USER_CONTROL 0
 #define DEBUG_NO_BEHAVIOR 0
 #define DEBUG_NO_ARROWS 0
+#define DEBUG_RENDER_AIMING 0
 
 extern HWND g_hWnd;
 
@@ -52,6 +53,8 @@ struct RenderState {
 extern RenderState g_RenderState;
 
 void RenderWorldLine(Vector2f screenCenterWorldPosition, Vector2f from, Vector2f to, COLORREF color);
+void RenderWorldBox(Vector2f screenCenterWorldPosition, Vector2f box_top_left, Vector2f box_bottom_right, COLORREF color);
+void RenderWorldText(Vector2f screenCenterWorldPosition, const std::string& text, const Vector2f& at, TextColor color, int flags = 0);
 void RenderLine(Vector2f from, Vector2f to, COLORREF color);
 // void RenderText(std::string text, Vector2f at, COLORREF color, int flags = 0);
 void RenderText(std::string, Vector2f at, TextColor color, int flags = 0);

--- a/Marvin/Shooter.cpp
+++ b/Marvin/Shooter.cpp
@@ -231,10 +231,10 @@ void LookForWallShot(GameProxy& game, Vector2f target_pos, Vector2f target_vel, 
   }
 }
 
-bool CanShoot(GameProxy& game, Vector2f player_pos, Vector2f solution, float proj_speed, float alive_time) {
-  float bullet_travel = (proj_speed + game.GetPlayer().velocity * game.GetPlayer().GetHeading()) * alive_time;
+bool CanShoot(GameProxy& game, Vector2f player_pos, Vector2f target, Vector2f weapon_velocity, float alive_time) {
+  float projectile_travel_sq = (weapon_velocity * alive_time).LengthSq();
 
-  if (player_pos.Distance(solution) > bullet_travel) return false;
+  if (player_pos.DistanceSq(target) > projectile_travel_sq) return false;
   if (game.GetMap().GetTileId(player_pos) == marvin::kSafeTileId) return false;
 
   return true;

--- a/Marvin/Shooter.h
+++ b/Marvin/Shooter.h
@@ -17,7 +17,7 @@ bool BounceShot(GameProxy& game, Vector2f target_pos, Vector2f target_vel, float
 void LookForWallShot(GameProxy& game, Vector2f target_pos, Vector2f target_vel, float proj_speed, int alive_time,
                      uint8_t bounces);
 
-bool CanShoot(GameProxy& game, Vector2f player_pos, Vector2f solution, float proj_speed, float alive_time);
+bool CanShoot(GameProxy& game, Vector2f player_pos, Vector2f solution, Vector2f weapon_velocity, float alive_time);
 
 bool CanShootGun(GameProxy& game, const Map& map, Vector2f player, Vector2f target);
 bool CanShootBomb(GameProxy& game, const Map& map, Vector2f player, Vector2f target);

--- a/Marvin/zones/Devastation.cpp
+++ b/Marvin/zones/Devastation.cpp
@@ -657,7 +657,7 @@ behavior::ExecuteResult DevaMoveToEnemyNode::Execute(behavior::ExecuteContext& c
   const Player* target = bb.ValueOr<const Player*>("Target", nullptr);
 
   if (!target) {
-    g_RenderState.RenderDebugText("  DevaMoveToEnemyNode: %llu", timer.GetElapsedTime());
+    g_RenderState.RenderDebugText("  DevaMoveToEnemyNode (no target): %llu", timer.GetElapsedTime());
     return behavior::ExecuteResult::Failure;
   }
 


### PR DESCRIPTION
- Calculate the real potential weapon velocity of a fired shot and use
  that for the calculations.
- Use the target's real position instead of solution when determining if
  the projectile can reach the target. This fixes the bug where it would
  never fire when a player was moving away but still within hitting
  distance.
- Fix a bug with the projectile travel distance calculation in CanShoot.
- Improve line of sight check so it doesn't fail as often when the
  target is against a wall.
- Create a debug display to help improve aiming calculations.